### PR TITLE
Bug-fixes

### DIFF
--- a/src/galasm.c
+++ b/src/galasm.c
@@ -2139,12 +2139,16 @@ WriteFuseFile(char *filename, int gal_type)
 	{
 	case GAL16V8:
 		num_of_col = MAX_FUSE_ADR16 + 1;
+		break;
 	case GAL20V8:
 		num_of_col = MAX_FUSE_ADR20 + 1;
+		break;
 	case GAL20RA10:
 		num_of_col = MAX_FUSE_ADR20RA10 + 1;
+		break;
 	case GAL22V10:
 		num_of_col = MAX_FUSE_ADR22V10 + 1;
+		break;
 	}
 
 	if ((fp = fopen(filename, (char *) "w")))

--- a/src/support.c
+++ b/src/support.c
@@ -46,8 +46,8 @@ char *GetBaseName(char *filename)
 
 	if((p = (char *)malloc(n+5)))
 	{
-		strncpy(p, filename, n); 
-		p[n+4] = '\0';
+		strncpy(p, filename, n);
+		strcpy(p+n, ".XXX");
 
 		return(p);
 	}


### PR DESCRIPTION
When playing with galasm, I spotted a couple of bugs:

 * The output filenames before the extension would be truncated because earlier NUL characters can appear in the file name returned by GetBaseName.
 * The fuse file was misformatted for e.g. GAL16V8 because of some missing 'break;'s.

These commits fix the bugs.